### PR TITLE
feat: implement item image download on the fly

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,8 @@ const WebSocket = require('ws');
 
 const fs = require("fs");
 
-const { getAdapterIp } = require('./server-scripts/adapter-selector')
+const { getAdapterIp } = require('./server-scripts/adapter-selector');
+const { downloadItemImage } = require('./server-scripts/image-downloader');
 
 
 
@@ -75,6 +76,17 @@ app.get('/settings', (req, res) => {
 });
 
 
+app.get('/images/Items/:fileName', async (req, res) => {
+  const fileName = req.params.fileName
+  const itemName = fileName.replace('.png', '')
+  const image = await downloadItemImage(itemName);
+
+  res.writeHead(200, {
+    'Content-Type': 'image/png',
+    'Content-Length': image.byteLength,
+  })
+  res.end(image)
+})
 
 
 app.get('/drawing', (req, res) => {
@@ -96,7 +108,7 @@ app.use('/scripts/Drawings', express.static(__dirname + '/scripts/Drawings'))
 app.use('/scripts/Utils', express.static(__dirname + '/scripts/Utils'));;
 app.use('/images/Resources', express.static(__dirname + '/images/Resources'));
 app.use('/images/Maps', express.static(__dirname + '/images/Maps'));
-app.use('/images/Items', express.static(__dirname + '/images/Items'));
+// app.use('/images/Items', express.static(__dirname + '/images/Items'));
 app.use('/images/Flags', express.static(__dirname + '/images/Flags'));
 app.use('/sounds', express.static(__dirname + '/sounds'));
 app.use('/config', express.static(__dirname + '/config'));

--- a/app.js
+++ b/app.js
@@ -76,7 +76,7 @@ app.get('/settings', (req, res) => {
 });
 
 
-app.get('/images/Items/:fileName', async (req, res) => {
+app.get('/retrieve-image/:fileName', async (req, res) => {
   const fileName = req.params.fileName
   const itemName = fileName.replace('.png', '')
   const image = await downloadItemImage(itemName);
@@ -108,7 +108,7 @@ app.use('/scripts/Drawings', express.static(__dirname + '/scripts/Drawings'))
 app.use('/scripts/Utils', express.static(__dirname + '/scripts/Utils'));;
 app.use('/images/Resources', express.static(__dirname + '/images/Resources'));
 app.use('/images/Maps', express.static(__dirname + '/images/Maps'));
-// app.use('/images/Items', express.static(__dirname + '/images/Items'));
+app.use('/images/Items', express.static(__dirname + '/images/Items'));
 app.use('/images/Flags', express.static(__dirname + '/images/Flags'));
 app.use('/sounds', express.static(__dirname + '/sounds'));
 app.use('/config', express.static(__dirname + '/config'));

--- a/scripts/Utils/DrawingUtils.js
+++ b/scripts/Utils/DrawingUtils.js
@@ -89,7 +89,14 @@
         {
             this.settings.preloadImageAndAddToList(src, folder)
             .then(() => console.log('Item loaded'))
-            .catch(() => console.log('Item not loaded'));
+            .catch(() => {
+                const autoDownload = this.settings.returnLocalBool('settingItemsAutoDownload')
+                if (!autoDownload) {
+                    console.log('Item not loaded')
+                    return;
+                }
+                this.settings.downloadAndPreloadImage(src, folder);
+            });
         }
     }
 

--- a/scripts/Utils/Settings.js
+++ b/scripts/Utils/Settings.js
@@ -249,6 +249,34 @@ class Settings
         }
     }
 
+    async downloadAndPreloadImage(path, container) {
+        switch (container) {
+            case 'Items':
+                const imageName = path.replace('/images/Items/', '');
+                const url = `/retrieve-image/${imageName}`
+                const blob = await (await fetch(url)).blob()
+                const objUrl = (window.URL || window.webkitURL).createObjectURL(blob)
+
+                return new Promise((res, rej) => {
+                    const img = new Image();
+                    img.onload = () => {
+                        this.item_images[path] = img; 
+                        res()
+                    };
+
+                    img.onerror = () => {
+                        this.item_images[path] = null;
+                        rej()
+                    };
+
+                    img.src = objUrl;
+                })
+                break;
+            default:
+                break;
+        }
+    }
+
     ClearPreloadedImages(container)
     {
         switch (container)

--- a/server-scripts/image-downloader.js
+++ b/server-scripts/image-downloader.js
@@ -1,0 +1,33 @@
+const fs = require('fs')
+
+const ITEM_IMAGE_PATH = './images/Items/';
+
+const downloadItemImage = async (itemName) => {
+    if (!itemName) return;
+
+    ensureFolderExist();
+
+    const itemPath = `${ITEM_IMAGE_PATH}${itemName}.png`;
+    const exists = fs.existsSync(itemPath);
+
+    if (exists) {
+        const image = fs.readFileSync(itemPath)
+        return image;
+    }
+    
+    const url = `https://render.albiononline.com/v1/item/${itemName}.png`
+    const arrayBuffer = await (await fetch(url)).arrayBuffer()
+    const content = Buffer.from(arrayBuffer)
+    fs.writeFileSync(itemPath, content, () => {})
+    return content;
+}
+
+const ensureFolderExist = () => {
+    const exists = fs.existsSync(ITEM_IMAGE_PATH);
+    if (exists) return;
+    fs.mkdirSync(ITEM_IMAGE_PATH);
+}
+
+module.exports = {
+    downloadItemImage,
+}

--- a/views/main/home.ejs
+++ b/views/main/home.ejs
@@ -67,6 +67,13 @@
 
               <label class="flex items-center space-x-2">
 
+                <input type="checkbox" id="settingItemsAutoDownload"" class="h-5 w-5 text-indigo-600 border-gray-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500">
+                <span class="dark:text-white ml-4">Items Auto Download</span>
+
+              </label>
+
+              <label class="flex items-center space-x-2">
+
                 <input type="checkbox" id="settingDistance" class="h-5 w-5 text-indigo-600 border-gray-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500">
                 <span class="dark:text-white ml-4">Distance</span>
 
@@ -106,6 +113,7 @@
           let settingMounted = document.getElementById("settingMounted");
           let settingItems = document.getElementById("settingItems");
           let settingItemsDev = document.getElementById("settingItemsDev");
+          let settingItemsAutoDownload = document.getElementById("settingItemsAutoDownload");
           let settingDistance = document.getElementById("settingDistance");
           let settingGuild = document.getElementById("settingGuild");
           let settingSound = document.getElementById("settingSound");
@@ -116,6 +124,7 @@
           settingMounted.checked = returnLocalBool("settingMounted");
           settingItems.checked =returnLocalBool("settingItems");
           settingItemsDev.checked = returnLocalBool("settingItemsDev");
+          settingItemsAutoDownload.checked = returnLocalBool("settingItemsAutoDownload");
           settingDistance.checked = returnLocalBool("settingDistance");
           settingGuild.checked = returnLocalBool("settingGuild");
           settingSound.checked = returnLocalBool("settingSound");
@@ -141,6 +150,10 @@
 
           settingItemsDev.addEventListener("click", () => {
               localStorage.setItem("settingItemsDev", settingItemsDev.checked);
+          });
+
+          settingItemsAutoDownload.addEventListener("click", () => {
+              localStorage.setItem("settingItemsAutoDownload", settingItemsAutoDownload.checked);
           });
 
           settingDistance.addEventListener("click", () => {


### PR DESCRIPTION
### Implement image download on the fly

Hi @Zeldruck , this update will make the app download the required item images on the fly, utilizing the albion render service  and saving them into the filesystem https://wiki.albiononline.com/wiki/API:Render_service

- if the file already exists, it will serve them from fs
- if the file does not exists, it will download the image from albion render service and save them into the fs for future use

please help to review them if it's worth to be included in the main branch
hopefully this will help to reduce the setup effort, cheers