### PR TITLE
fix: set current directory for the run.bat script

### DIFF
--- a/_RUN.bat
+++ b/_RUN.bat
@@ -1,4 +1,5 @@
 @echo off
+cd %~dp0
 echo Running the radar
 echo.
 echo node app.js


### PR DESCRIPTION
Problem: If script is started via start bar search, next error appears: `Error: Cannot find module 'C:\Windows\System32\app.js'`

Solution: before calling `node`, change current directory to one where script is located